### PR TITLE
Attribute path completion for nix-env, etc.

### DIFF
--- a/_nix-build
+++ b/_nix-build
@@ -1,6 +1,8 @@
 #compdef nix-build
 #autoload
 
+local command_name=nix-build
+
 _nix-common-options
 
 local -a _nix_build_opts
@@ -26,4 +28,4 @@ _arguments \
   $_nix_boilerplate_opts \
   $_nix_common_opts \
   $_nix_build_opts \
-  '*::Paths:_files'
+  '*:Paths:_files'

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -45,31 +45,47 @@ _nix_installed_packages () {
 }
 
 
-# Prints the attribute names of the given path
-# eg.
-# Input: nixos python2Packages
-# Output: whitespace separated attributes of nixos.python2Packages
+# Generate nix code creating the default expression used by nix-env -iA
+_nix_gen_defexpr () {
+    setopt local_options null_glob
+    local -a result
+    local -a queue=($1)
+    while [[ ${#queue} > 0 ]]; do
+        local current=$queue[1]
+        shift queue
+        if [[ -e $current/default.nix ]]; then
+            result+=($current)
+        else
+            queue+=($current/*)
+        fi
+    done
+
+    local nix_expr="{\n"
+    for p in $result; do
+        nix_expr+="$(basename $p) = import $p {};"
+        nix_expr+="\n"
+    done
+    nix_expr+="}"
+
+    echo $nix_expr
+}
+
+
+# Prints the attribute names (whitespace separated) of the given path
+# Eg. input: nixos.python2Packages
 _nix_attr_names () {
     setopt local_options pipefail
 
-    # Could simplify by splicing the attr path into the heredoc
-    # ie. builtins.attrName $path where path=nixos.python2Packages
+    local attr_path=top${1:+.$1}
 
-    local attr_list="$@"
-    local quoted_attr_list=($(echo $attr_list | sed 's/\([^ ]\+\)/\"\1\"/g'))
-
-    nix-instantiate --eval --arg attrs "[ $quoted_attr_list ]" - \
+    nix-instantiate --eval - \
           <<NIX_FILE | tr '[]"' ' '
-                { attrs ? null}:
-
                 let
-                  top = {};
-                  top.nixos = import <nixpkgs> {};
-                  foldAttr = set: s: builtins.getAttr s set;
-                  attr_opt = builtins.foldl' foldAttr top attrs;
+                  top = $(_nix_gen_defexpr ~/.nix-defexpr);
                 in
-                  builtins.attrNames attr_opt
+                  builtins.attrNames $attr_path
 NIX_FILE
+
     return $?
 }
 
@@ -81,28 +97,28 @@ _nix_attr_paths () {
         if [[ $attr_opt -le 0 || "$1" == "attr_path" ]]; then
             attr_opt=0
         fi
-        # attr_opt=$(test ( $attr_opt -le 0 ) -o ( "$1" = "attr_path" ))
         shift
     done
     if [[ $attr_opt -gt 0 ]]; then
         return
     fi
 
-    # Add a 'X' last to make sure "nixos." results in two array entries below
-    local attr_path=${words[CURRENT]}X
-    local attr_list=( ${=${attr_path//./ }} )
+    local attr_path=""
+    if [[ $words[CURRENT] == *.* ]]; then
+        attr_path=${words[CURRENT]%.*}
+    fi
 
     local -a result # must be on separate line to capture error code..
-    result=( $(_nix_attr_names $attr_list[1,-2]) ) 2>/dev/null
+    result=( $(_nix_attr_names $attr_path) ) 2>/dev/null
 
     if [[ $? > 0 ]]; then
         # Probably because of invalid attribute path
         return
     fi
 
-    local prefix=${(j:.:)attr_list[1,-2]}
-    if [[ -n $prefix ]]; then
-        prefix=${prefix}.
+    local prefix
+    if [[ -n $attr_path ]]; then
+        prefix=${attr_path}.
     fi
 
     _values -s . "Packages" $(echo $result | sed "s/\([^ ]\+\)/$prefix\1/g")

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -45,23 +45,24 @@ _nix_installed_packages () {
 }
 
 _nix_attr_paths () {
-  # Add a 'X' last to make sure "nixos." results in two array entries below
-  local attr_path=${words[CURRENT]}X
-  local attr_list=($(echo $attr_path | tr . ' '))
-  local quoted_attr_list=($(echo $attr_list | sed -r 's/([^ ]*)/\"\1\"/g'))
+    # Add a 'X' last to make sure "nixos." results in two array entries below
+    local attr_opt=1
+    local attr_path=${words[CURRENT]}X
+    local attr_list=($(echo $attr_path | tr . ' '))
+    local quoted_attr_list=($(echo $attr_list | sed -r 's/([^ ]*)/\"\1\"/g'))
 
-  local -a result=(
-    $(nix-instantiate --eval --arg attrs "[ $quoted_attr_list[1,-2] ]" \
-        =(<<NIX_FILE
-            { attrs ? null}:
+    local -a result=(
+        $(nix-instantiate --eval --arg attrs "[ $quoted_attr_list[1,-2] ]" \
+            =(<<NIX_FILE
+                { attrs ? null}:
 
-            let
-              top = {};
-              top.nixos = import <nixpkgs> {};
-              foldAttr = set: s: builtins.getAttr s set;
-              attr = builtins.foldl' foldAttr top attrs;
-            in
-            builtins.attrNames attr
+                let
+                  top = {};
+                  top.nixos = import <nixpkgs> {};
+                  foldAttr = set: s: builtins.getAttr s set;
+                  attr_opt = builtins.foldl' foldAttr top attrs;
+                in
+                builtins.attrNames attr_opt
 NIX_FILE
 ) \
         | tr '[]"' ' '))

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -74,6 +74,7 @@ _nix_gen_defexpr () {
 # Prints the attribute names (whitespace separated) of the given path
 # Arguments: attribute_path [top_level_expr_path]
 #   top_level_expr is interpreted as 'nix-env --file'
+#   if top_level_expr is omitted it defaults to what 'nix-env -iA' uses
 # Eg. _nix_attr_names nixos.python2Packages mypkgs.nix
 _nix_attr_names () {
     setopt local_options pipefail
@@ -83,7 +84,13 @@ _nix_attr_names () {
 
     local defexpr
     if [[ -n $defexpr_path ]]; then
-        defexpr="import ${defexpr_path:a}"
+        if [[ -e $defexpr_path ]]; then
+            # If the path exist use the absolute path to make sure import will
+            # accept it.
+            # (Otherwise the path is likely a <nixpkgs> notation)
+            defexpr_path=${defexpr_path:a}
+        fi
+        defexpr="import $defexpr_path"
     elif [[ $command_name == nix-env ]]; then
         defexpr=$(_nix_gen_defexpr ~/.nix-defexpr)
     fi
@@ -125,11 +132,18 @@ _nix_attr_paths () {
         fi
     fi
 
+    # Remove one level of shell quoting to make sure we see the same value as
+    # the nix-* program will see.
+    # ($opt_args and $line contain the verbatim string:
+    #  eg. given `nix-shell '<nixpkgs>' -A ` $line[1] will be `'<nixpkgs>'` while
+    #  nix-shell will see `<nixpkgs>`)
+    defexpr_path=${(Q)defexpr_path}
+
     local -a result # must be on separate line to capture error code..
     result=( $(_nix_attr_names "$attr_path" $defexpr_path) ) 2>/dev/null
 
     if [[ $? > 0 ]]; then
-        # Probably because of invalid attribute path
+        # Probably because of invalid attribute path or error in top-level expr
         return
     fi
 

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -44,8 +44,38 @@ _nix_installed_packages () {
     _values "Nix Packages" $packages
 }
 
+
+# Prints the attribute names of the given path
+# eg.
+# Input: nixos python2Packages
+# Output: whitespace separated attributes of nixos.python2Packages
+_nix_attr_names () {
+    setopt local_options pipefail
+
+    # Could simplify by splicing the attr path into the heredoc
+    # ie. builtins.attrName $path where path=nixos.python2Packages
+
+    local attr_list="$@"
+    local quoted_attr_list=($(echo $attr_list | sed 's/\([^ ]\+\)/\"\1\"/g'))
+
+    nix-instantiate --eval --arg attrs "[ $quoted_attr_list ]" - \
+          <<NIX_FILE | tr '[]"' ' '
+                { attrs ? null}:
+
+                let
+                  top = {};
+                  top.nixos = import <nixpkgs> {};
+                  foldAttr = set: s: builtins.getAttr s set;
+                  attr_opt = builtins.foldl' foldAttr top attrs;
+                in
+                  builtins.attrNames attr_opt
+NIX_FILE
+    return $?
+}
+
+# Complete attribute paths
 _nix_attr_paths () {
-    # Add a 'X' last to make sure "nixos." results in two array entries below
+    # Check if we're suppose to complete attr paths
     local attr_opt=1
     while [[ -n $1 ]]; do
         if [[ $attr_opt -le 0 || "$1" == "attr_path" ]]; then
@@ -57,31 +87,25 @@ _nix_attr_paths () {
     if [[ $attr_opt -gt 0 ]]; then
         return
     fi
+
+    # Add a 'X' last to make sure "nixos." results in two array entries below
     local attr_path=${words[CURRENT]}X
-    local attr_list=($(echo $attr_path | tr . ' '))
-    local quoted_attr_list=($(echo $attr_list | sed -r 's/([^ ]*)/\"\1\"/g'))
+    local attr_list=( ${=${attr_path//./ }} )
 
-    local -a result=(
-        $(nix-instantiate --eval --arg attrs "[ $quoted_attr_list[1,-2] ]" \
-            =(<<NIX_FILE
-                { attrs ? null}:
+    local -a result # must be on separate line to capture error code..
+    result=( $(_nix_attr_names $attr_list[1,-2]) ) 2>/dev/null
 
-                let
-                  top = {};
-                  top.nixos = import <nixpkgs> {};
-                  foldAttr = set: s: builtins.getAttr s set;
-                  attr_opt = builtins.foldl' foldAttr top attrs;
-                in
-                builtins.attrNames attr_opt
-NIX_FILE
-) \
-        | tr '[]"' ' '))
+    if [[ $? > 0 ]]; then
+        # Probably because of invalid attribute path
+        return
+    fi
 
-  local prefix=${(j:.:)attr_list[1,-2]}
-  if [[ -n $prefix ]]; then
-    prefix=${prefix}.
-  fi
-  _values -s . "Packages" $(echo $result | sed -r "s/([^ ]*)/$prefix\1/g")
+    local prefix=${(j:.:)attr_list[1,-2]}
+    if [[ -n $prefix ]]; then
+        prefix=${prefix}.
+    fi
+
+    _values -s . "Packages" $(echo $result | sed "s/\([^ ]\+\)/$prefix\1/g")
 }
 
 _nix_profiles () {

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -167,7 +167,7 @@ _nix_common_nixos_rebuild=(
 _nix_common_opts=(
   $_nix_common_nixos_rebuild \
   $_nix_search_path_args \
-  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:attrPath:_nix_attr_paths'\
+  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]'\
   '(--expr -E)'{--expr,-E}'[Interpret command line args as Nix expressions]:*:Files:_files'\
   '*--arg[Argument to pass to the Nix function]:Name:( ):Value:( )'\
   '--argstr[Like --arg, but the value is a string]: :'\

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -84,7 +84,7 @@ _nix_attr_names () {
     local defexpr
     if [[ -n $defexpr_path ]]; then
         defexpr="import ${defexpr_path:a}"
-    else
+    elif [[ $command_name == nix-env ]]; then
         defexpr=$(_nix_gen_defexpr ~/.nix-defexpr)
     fi
 
@@ -101,28 +101,28 @@ NIX_FILE
     return $?
 }
 
+
 # Complete attribute paths
 _nix_attr_paths () {
-    # Check if we're suppose to complete attr paths
-    local attr_opt=1
-    while [[ -n $1 ]]; do
-        if [[ $attr_opt -le 0 || "$1" == "attr_path" ]]; then
-            attr_opt=0
-        fi
-        shift
-    done
-    if [[ $attr_opt -gt 0 ]]; then
-        return
-    fi
-
     local attr_path=""
     if [[ $words[CURRENT] == *.* ]]; then
         attr_path=${words[CURRENT]%.*}
     fi
 
-    local defexpr_path=$opt_args[-f]
-    if [[ -z $defexpr_path ]]; then
-        defexpr_path=$opt_args[--file]
+    local defexpr_path
+    if [[ $command_name == nix-env ]]; then
+        defexpr_path=$opt_args[-f]
+        if [[ -z $defexpr_path ]]; then
+            defexpr_path=$opt_args[--file]
+        fi
+    else
+        if [[ $line ]]; then
+            defexpr_path=$line[1]
+        elif [[ -e shell.nix && $command_name == nix-shell ]]; then
+            defexpr_path=shell.nix
+        elif [[ -e default.nix ]]; then
+            defexpr_path=default.nix
+        fi
     fi
 
     local -a result # must be on separate line to capture error code..

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -44,6 +44,35 @@ _nix_installed_packages () {
     _values "Nix Packages" $packages
 }
 
+_nix_attr_paths () {
+  # Add a 'X' last to make sure "nixos." results in two array entries below
+  local attr_path=${words[-1]}X
+  local attr_list=($(echo $attr_path | tr . ' '))
+  local quoted_attr_list=($(echo $attr_list | sed -r 's/([^ ]*)/\"\1\"/g'))
+
+  local -a result=(
+    $(nix-instantiate --eval --arg attrs "[ $quoted_attr_list[1,-2] ]" \
+        =(<<NIX_FILE
+            { attrs ? null}:
+
+            let
+              top = {};
+              top.nixos = import <nixpkgs> {};
+              foldAttr = set: s: builtins.getAttr s set;
+              attr = builtins.foldl' foldAttr top attrs;
+            in
+            builtins.attrNames attr
+NIX_FILE
+) \
+        | tr '[]"' ' '))
+
+  local prefix=${(j:.:)attr_list[1,-2]}
+  if [[ -n $prefix ]]; then
+    prefix=${prefix}.
+  fi
+  _values -s . "Packages" $(echo $result | sed -r "s/([^ ]*)/$prefix\1/g")
+}
+
 _nix_profiles () {
     local -a profiles
     profiles=($(find /nix/var/nix/profiles))
@@ -138,7 +167,7 @@ _nix_common_nixos_rebuild=(
 _nix_common_opts=(
   $_nix_common_nixos_rebuild \
   $_nix_search_path_args \
-  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:attrPath:_files -/'\
+  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:attrPath:_nix_attr_paths'\
   '(--expr -E)'{--expr,-E}'[Interpret command line args as Nix expressions]:*:Files:_files'\
   '*--arg[Argument to pass to the Nix function]:Name:( ):Value:( )'\
   '--argstr[Like --arg, but the value is a string]: :'\

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -235,7 +235,7 @@ _nix_common_nixos_rebuild=(
 _nix_common_opts=(
   $_nix_common_nixos_rebuild \
   $_nix_search_path_args \
-  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]'\
+  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:Packages:_nix_attr_paths'\
   '(--expr -E)'{--expr,-E}'[Interpret command line args as Nix expressions]:*:Files:_files'\
   '*--arg[Argument to pass to the Nix function]:Name:( ):Value:( )'\
   '--argstr[Like --arg, but the value is a string]: :'\

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -45,7 +45,7 @@ _nix_installed_packages () {
 }
 
 
-# Generate nix code creating the default expression used by nix-env -iA
+# Generate nix code creating the default expression used by 'nix-env -iA'
 _nix_gen_defexpr () {
     setopt local_options null_glob
     local -a result
@@ -72,16 +72,28 @@ _nix_gen_defexpr () {
 
 
 # Prints the attribute names (whitespace separated) of the given path
-# Eg. input: nixos.python2Packages
+# Arguments: attribute_path [top_level_expr_path]
+#   top_level_expr is interpreted as 'nix-env --file'
+# Eg. _nix_attr_names nixos.python2Packages mypkgs.nix
 _nix_attr_names () {
     setopt local_options pipefail
 
     local attr_path=top${1:+.$1}
+    local defexpr_path=$2
+
+    local defexpr
+    if [[ -n $defexpr_path ]]; then
+        defexpr="import ${defexpr_path:a}"
+    else
+        defexpr=$(_nix_gen_defexpr ~/.nix-defexpr)
+    fi
 
     nix-instantiate --eval - \
           <<NIX_FILE | tr '[]"' ' '
                 let
-                  top = $(_nix_gen_defexpr ~/.nix-defexpr);
+                  top_gen = $defexpr;
+                  # --file arguments can be a lambda producing a record too
+                  top = if builtins.typeOf top_gen == "lambda" then top_gen {} else top_gen ;
                 in
                   builtins.attrNames $attr_path
 NIX_FILE
@@ -108,8 +120,13 @@ _nix_attr_paths () {
         attr_path=${words[CURRENT]%.*}
     fi
 
+    local defexpr_path=$opt_args[-f]
+    if [[ -z $defexpr_path ]]; then
+        defexpr_path=$opt_args[--file]
+    fi
+
     local -a result # must be on separate line to capture error code..
-    result=( $(_nix_attr_names $attr_path) ) 2>/dev/null
+    result=( $(_nix_attr_names "$attr_path" $defexpr_path) ) 2>/dev/null
 
     if [[ $? > 0 ]]; then
         # Probably because of invalid attribute path

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -110,25 +110,33 @@ NIX_FILE
 
 
 # Complete attribute paths
+# NB: this function expects an optional argument so the user must make sure
+#     zsh completion functions doesn't supply arguments. eg. when used in a
+#     action spec to _arguments the function should be prefixed with a space:
+#     `: _nix_attr_paths`
+#     Without the space prefix _arguments will inject lots of arguments. These
+#     are available(?) in the `expl` array anyway
 _nix_attr_paths () {
     local attr_path=""
     if [[ $words[CURRENT] == *.* ]]; then
         attr_path=${words[CURRENT]%.*}
     fi
 
-    local defexpr_path
-    if [[ $command_name == nix-env ]]; then
-        defexpr_path=$opt_args[-f]
-        if [[ -z $defexpr_path ]]; then
-            defexpr_path=$opt_args[--file]
-        fi
-    else
-        if [[ $line ]]; then
-            defexpr_path=$line[1]
-        elif [[ -e shell.nix && $command_name == nix-shell ]]; then
-            defexpr_path=shell.nix
-        elif [[ -e default.nix ]]; then
-            defexpr_path=default.nix
+    local defexpr_path=$1
+    if [[ -z $defexpr_path ]]; then
+        if [[ $command_name == nix-env ]]; then
+            defexpr_path=$opt_args[-f]
+            if [[ -z $defexpr_path ]]; then
+                defexpr_path=$opt_args[--file]
+            fi
+        else
+            if [[ $line ]]; then
+                defexpr_path=$line[1]
+            elif [[ -e shell.nix && $command_name == nix-shell ]]; then
+                defexpr_path=shell.nix
+            elif [[ -e default.nix ]]; then
+                defexpr_path=default.nix
+            fi
         fi
     fi
 
@@ -144,7 +152,7 @@ _nix_attr_paths () {
 
     if [[ $? > 0 ]]; then
         # Probably because of invalid attribute path or error in top-level expr
-        return
+        return 1
     fi
 
     local prefix
@@ -249,7 +257,7 @@ _nix_common_nixos_rebuild=(
 _nix_common_opts=(
   $_nix_common_nixos_rebuild \
   $_nix_search_path_args \
-  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:Packages:_nix_attr_paths'\
+  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:Packages: _nix_attr_paths'\
   '(--expr -E)'{--expr,-E}'[Interpret command line args as Nix expressions]:*:Files:_files'\
   '*--arg[Argument to pass to the Nix function]:Name:( ):Value:( )'\
   '--argstr[Like --arg, but the value is a string]: :'\

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -121,7 +121,7 @@ _nix_attr_paths () {
         prefix=${attr_path}.
     fi
 
-    _values -s . "Packages" $(echo $result | sed "s/\([^ ]\+\)/$prefix\1/g")
+    _values -s . "Packages" ${prefix}${^result}
 }
 
 _nix_profiles () {

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -47,6 +47,16 @@ _nix_installed_packages () {
 _nix_attr_paths () {
     # Add a 'X' last to make sure "nixos." results in two array entries below
     local attr_opt=1
+    while [[ -n $1 ]]; do
+        if [[ $attr_opt -le 0 || "$1" == "attr_path" ]]; then
+            attr_opt=0
+        fi
+        # attr_opt=$(test ( $attr_opt -le 0 ) -o ( "$1" = "attr_path" ))
+        shift
+    done
+    if [[ $attr_opt -gt 0 ]]; then
+        return
+    fi
     local attr_path=${words[CURRENT]}X
     local attr_list=($(echo $attr_path | tr . ' '))
     local quoted_attr_list=($(echo $attr_list | sed -r 's/([^ ]*)/\"\1\"/g'))

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -46,7 +46,7 @@ _nix_installed_packages () {
 
 _nix_attr_paths () {
   # Add a 'X' last to make sure "nixos." results in two array entries below
-  local attr_path=${words[-1]}X
+  local attr_path=${words[CURRENT]}X
   local attr_list=($(echo $attr_path | tr . ' '))
   local quoted_attr_list=($(echo $attr_list | sed -r 's/([^ ]*)/\"\1\"/g'))
 

--- a/_nix-env
+++ b/_nix-env
@@ -45,6 +45,7 @@ if (( CURRENT==1 )); then
     return
 fi
 
+# Workaround:
 # opt_args doesn't contain the first option
 # so can't detect stacked options like '-iA'
 typeset -Ua options
@@ -122,7 +123,6 @@ case "$words[1]" in
       '--xml[Print output as XML]'\
       '--json[Print output as JSON]'\
       '--meta[Print all meta attributes: only available with --xml]'\
-      '*:Packages:_nix_attr_paths'\
     ;;
   --switch-profile|-[^-]#S[^-]#)
     _arguments ':Profile:_nix_profiles'

--- a/_nix-env
+++ b/_nix-env
@@ -24,7 +24,7 @@ _nix_env_common_opts=(
   '(--profile -p)'{--profile,-p}'[Specify the profile to use]:Path:_nix_profiles'\
   $_nix_dry_run \
   '--system-filter[Only show derivations matching the specified platform]:system:_nix_systems'\
-  '*:::Package:_nix_attr_paths'\
+  '*:Package:_nix_attr_paths'\
 )
 
 local -a _nix_env_b

--- a/_nix-env
+++ b/_nix-env
@@ -48,23 +48,23 @@ fi
 typeset -Ua options
 for opt in $words; do
     case $opt in
-        --attr|-A)
+        --attr|-[^-]#A[^-]#)
             options+=(attr_path)
             ;;
     esac
 done
 
 case "$words[1]" in
-  --install|-i)
-    _arguments -O options $_nix_env_common_opts \
+  --install|-[^-]#i[^-]#)
+    _arguments -s -O options $_nix_env_common_opts \
       $_nix_env_b \
       $_nix_env_from_profile \
       '(--preserve-installed -P)'{--preserve-installed,-P}'[Do not remove derivations with the same name]' \
       '(--remove-all -r)'{--remove-all,-r}'[Remove all previously installed packages prior to installing]' \
       '*:Package:_nix_attr_paths'\
     ;;
-  --upgrade|-u)
-    _arguments $_nix_env_common_opts \
+  --upgrade|-[^-]#u[^-]#)
+    _arguments -s $_nix_env_common_opts \
       $_nix_env_b \
       $_nix_env_from_profile \
       '(-lt -leq -eq --always)--lt[Upgrade derivations with newer versions (default)]' \
@@ -73,8 +73,8 @@ case "$words[1]" in
       '(-lt -leq -eq --always)--always[Upgrade even if version number decreases]' \
       '*:Packages:_nix_installed_packages'
     ;;
-  --uninstall|-e)
-    _arguments '*::Packages:_nix_installed_packages'
+  --uninstall|-[^-]#e[^-]#)
+    _arguments -s '*::Packages:_nix_installed_packages'
     ;;
   --set-flag)
     _set_flag_attrs=(
@@ -103,8 +103,8 @@ case "$words[1]" in
         _nix_installed_packages
     fi
     ;;
-  --query|-q)
-    _arguments -O options $_nix_env_common_opts \
+  --query|-[^-]#q[^-]#)
+    _arguments -s -O options $_nix_env_common_opts \
       '(--available -a)'{--available,-a}'[Display all installable derivations]' \
       $_nix_output_opts \
       $_nix_env_b \
@@ -121,14 +121,14 @@ case "$words[1]" in
       '--meta[Print all meta attributes: only available with --xml]'\
       '*:Packages:_nix_attr_paths'\
     ;;
-  --switch-profile|-S)
-    _arguments '*:Profile:_nix_profiles'
+  --switch-profile|-[^-]#S[^-]#)
+    _arguments ':Profile:_nix_profiles'
     ;;
   --delete-generations)
     _arguments \
       '*::Generations:_nix_generations'
     ;;
-  --switch-generation|-G)
-    _arguments '*::Generations:_nix_generations'
+  --switch-generation|-[^-]#G[^-]#)
+    _arguments '::Generations:_nix_generations'
     ;;
 esac

--- a/_nix-env
+++ b/_nix-env
@@ -45,6 +45,8 @@ if (( CURRENT==1 )); then
     return
 fi
 
+# opt_args doesn't contain the first option
+# so can't detect stacked options like '-iA'
 typeset -Ua options
 for opt in $words; do
     case $opt in
@@ -56,7 +58,8 @@ done
 
 case "$words[1]" in
   --install|-[^-]#i[^-]#)
-    _arguments -s -O options $_nix_env_common_opts \
+    _arguments -s -O options \
+      $_nix_env_common_opts \
       $_nix_env_b \
       $_nix_env_from_profile \
       '(--preserve-installed -P)'{--preserve-installed,-P}'[Do not remove derivations with the same name]' \

--- a/_nix-env
+++ b/_nix-env
@@ -4,6 +4,8 @@
 emulate -L zsh
 setopt extendedglob
 
+local command_name=nix-env
+
 _nix-common-options
 
 local -a _1st_arguments
@@ -48,24 +50,24 @@ fi
 # Workaround:
 # opt_args doesn't contain the first option
 # so can't detect stacked options like '-iA'
-typeset -Ua options
+local expect_attr_paths=false
 for opt in $words; do
     case $opt in
         --attr|-[^-]#A[^-]#)
-            options+=(attr_path)
+            expect_attr_paths=true
             ;;
     esac
 done
 
 case "$words[1]" in
   --install|-[^-]#i[^-]#)
-    _arguments -s -O options \
+    _arguments -s \
       $_nix_env_common_opts \
       $_nix_env_b \
       $_nix_env_from_profile \
       '(--preserve-installed -P)'{--preserve-installed,-P}'[Do not remove derivations with the same name]' \
       '(--remove-all -r)'{--remove-all,-r}'[Remove all previously installed packages prior to installing]' \
-      '*:Package:_nix_attr_paths'\
+      '*:Package:{if $expect_attr_paths; then _nix_attr_paths ; fi}'\
     ;;
   --upgrade|-[^-]#u[^-]#)
     _arguments -s $_nix_env_common_opts \

--- a/_nix-env
+++ b/_nix-env
@@ -24,6 +24,7 @@ _nix_env_common_opts=(
   '(--profile -p)'{--profile,-p}'[Specify the profile to use]:Path:_nix_profiles'\
   $_nix_dry_run \
   '--system-filter[Only show derivations matching the specified platform]:system:_nix_systems'\
+  '*:::Package:_nix_attr_paths'\
 )
 
 local -a _nix_env_b

--- a/_nix-env
+++ b/_nix-env
@@ -1,6 +1,9 @@
 #compdef nix-env
 #autoload
 
+emulate -L zsh
+setopt extendedglob
+
 _nix-common-options
 
 local -a _1st_arguments

--- a/_nix-env
+++ b/_nix-env
@@ -24,7 +24,6 @@ _nix_env_common_opts=(
   '(--profile -p)'{--profile,-p}'[Specify the profile to use]:Path:_nix_profiles'\
   $_nix_dry_run \
   '--system-filter[Only show derivations matching the specified platform]:system:_nix_systems'\
-  '*:Package:_nix_attr_paths'\
 )
 
 local -a _nix_env_b
@@ -43,13 +42,23 @@ if (( CURRENT==1 )); then
     return
 fi
 
+typeset -Ua options
+for opt in $words; do
+    case $opt in
+        --attr|-A)
+            options+=(attr_path)
+            ;;
+    esac
+done
+
 case "$words[1]" in
   --install|-i)
-    _arguments $_nix_env_common_opts \
+    _arguments -O options $_nix_env_common_opts \
       $_nix_env_b \
       $_nix_env_from_profile \
       '(--preserve-installed -P)'{--preserve-installed,-P}'[Do not remove derivations with the same name]' \
       '(--remove-all -r)'{--remove-all,-r}'[Remove all previously installed packages prior to installing]' \
+      '*:Package:_nix_attr_paths'\
     ;;
   --upgrade|-u)
     _arguments $_nix_env_common_opts \
@@ -92,7 +101,7 @@ case "$words[1]" in
     fi
     ;;
   --query|-q)
-    _arguments $_nix_env_common_opts \
+    _arguments -O options $_nix_env_common_opts \
       '(--available -a)'{--available,-a}'[Display all installable derivations]' \
       $_nix_output_opts \
       $_nix_env_b \
@@ -106,7 +115,8 @@ case "$words[1]" in
       '--description[Print description]' \
       '--xml[Print output as XML]'\
       '--json[Print output as JSON]'\
-      '--meta[Print all meta attributes: only available with --xml]'
+      '--meta[Print all meta attributes: only available with --xml]'\
+      '*:Packages:_nix_attr_paths'\
     ;;
   --switch-profile|-S)
     _arguments '*:Profile:_nix_profiles'

--- a/_nix-instantiate
+++ b/_nix-instantiate
@@ -1,6 +1,8 @@
 #compdef nix-instantiate
 #autoload
 
+local command_name=nix-instantiate
+
 _nix-common-options
 
 # --no-location: undocumented arg

--- a/_nix-shell
+++ b/_nix-shell
@@ -10,7 +10,7 @@ _nix_shell_opts=(
   '--command[Run a command instead of starting an interactive shell]:Command:_command_names' \
   '--exclude[Do not build any dependencies which match this regex]:Regex:( )' \
   '--pure[Clear the environment before starting the interactive shell]' \
-  '(--packages -p)'{--packages,-p}'[Set up an environment where the given packages are present]:*:Packages:_nix_installed_packages' \
+  '(--packages -p)'{--packages,-p}'[Set up an environment where the given packages are present]:*:Packages: _nix_attr_paths "<nixpkgs>"' \
 )
 
 _arguments \

--- a/_nix-shell
+++ b/_nix-shell
@@ -1,6 +1,8 @@
 #compdef nix-shell
 #autoload
 
+local command_name=nix-shell
+
 _nix-common-options
 
 local -a _nix_shell_opts


### PR DESCRIPTION
Cleaned up version of PR #3. Unless there's more compatibility problems I think this should be close to finished.

Nix-env completion now understands multiple channels and the `--file` argument.

A quirk with the implementation is that completion continues into the derivations. (this is probably fairly simple to fix)

<del>Only `nix-env` has useful completion, but it shouldn't be too much work getting `nix-shell` and `nix-build` too work either. </del>

<br>
Of course, given the approaching cli redesign (https://github.com/NixOS/nix/issues/779) it might not make sense to pour too much work into the details of the current command set.

(In collaboration with @hedning)
