### PR TITLE
Fix $NIX_SHELL detection

### DIFF
--- a/nix.plugin.zsh
+++ b/nix.plugin.zsh
@@ -5,7 +5,7 @@ alias ni='nix-env -iA'
 alias ns='nix-env -qaP'
 
 function prompt_nix_shell_precmd {
-  if [[ ${IN_NIX_SHELL} -eq 1 ]] then
+  if [[ -n ${IN_NIX_SHELL} && ${IN_NIX_SHELL} != "0" ]] then
     if [[ -n ${IN_WHICH_NIX_SHELL} ]] then
       NIX_SHELL_NAME=": ${IN_WHICH_NIX_SHELL}"
     fi


### PR DESCRIPTION
In recent versions of Nix, NIX_SHELL is no longer set to 1 but "pure" or "impure".  This means that the prompt would no longer change.  This change accommodates for both cases (I'm pretty sure).