### PR TITLE
The CLI options `-E` and `-A` can be applied multiple times

### DIFF
--- a/_nix-build
+++ b/_nix-build
@@ -5,7 +5,7 @@ _nix-common-options
 
 local -a _nix_build_opts
 _nix_build_opts=(
-  '(--expr -E)'{--expr,-E}'[Interpret command line args as Nix expressions]'
+  '*'{--expr,-E}'[Interpret command line args as Nix expressions]'
   '--drv-link[Add a symlink to the store derivation]:Symlink Name:( )' \
   '--add-drv-link[Shorthand for --drv-link ./derivation]' \
   '--no-out-link[Do not create a symlink to the output path]' \

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -503,7 +503,7 @@ _nix_common_nixos_rebuild=(
 # Used in: nix-build, nix-env, nix-instantiate, nix-shell
 _nix_common_opts=(
   $_nix_common_nixos_rebuild \
-  '(--attr -A)'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:Packages: _nix_complete_attr_paths'\
+  '*'{--attr,-A}'[Select an attribute from the top-level Nix expression being evaluated]:Packages: _nix_complete_attr_paths'\
   '*--arg[Argument to pass to the Nix function]:Name:_nix_complete_function_arg:Value: '\
   '*--argstr[Like --arg, but the value is a string]:Name:_nix_complete_function_arg:String: '\
   '--max-silent-time[Builder times out after not producing stdout/stderr for x seconds]:Seconds:( )'\


### PR DESCRIPTION
E.g. the following snippet works perfectly fine:

```
nix-build release.nix -A foo -A bar
```

This will result in two linked output paths in the current working
directory named `result` and `result-2`. Until now it wasn't possible to
gain autocompletion for the second/third/nth `-A`.

The same rule applies for `-E`.