### PR TITLE
Add basic completions for `nixos-option`

### DIFF
--- a/_nixos-option
+++ b/_nixos-option
@@ -1,0 +1,19 @@
+#compdef nixos-option
+#autoload
+_nix-common-options # import _nix_attr_paths etc.
+
+_nixos-option-opts() {
+    local options='
+      with import <nixpkgs/lib>;
+      filterAttrsRecursive
+        (k: _: substring 0 1 k != "_")
+        (evalModules { modules = import <nixpkgs/nixos/modules/module-list.nix>; }).options
+    '
+
+    _nix_attr_paths $options
+}
+
+_arguments \
+    $_nix_search_path_args \
+    '--xml[Render as XML]' \
+    '*:NixOS module options:_nixos-option-opts'


### PR DESCRIPTION
The `nixos-option` script can be fairly helpful for option discovery on
the currently activated system configuration. However I figured its
usefulness to be quite limited as it doesn't have a working
autocompletion and you have to manually type in full option names.

This patch aims to improve the situation by parsing the module system
using `lib.evalModules` and matching the results against the given `$1`.

Internally the `_nix_attr_paths` completion helper is used to provide
proper completion for a given attribute set.

The only known limitation is that option properties (like `default`,
`description`, etc.) are autocompleted as well although they can't be
handled by `nixos-option`. This happens as it can't be reliably decided
whether an attribute name is part of an option or an option itself (e.g.
`boot.loader.grub.default`).

It could be worked around this issue by
extracting all affected arguments using `lib.functionArgs` and filter
all of them if they're part of an option (attribute set with `_type` ==
`option`). However this doesn't apply for all attribute names (e.g.
`declarations` or `definitions`) and not all options properly evaluate
ATM (e.g. `fileSystems`).

Co-authored-by: Tor Hedin Brønner <torhedinbronner@gmail.com>