### PR TITLE
nixos-build-vms: Complete `--help` and `--option`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project aims to provide a highly complete set of ZSH completions for [Nix](
 
 NixOS
 ----------------------
-Setting `programs.zsh.enable = true` in `/etc/nix/configuration.nix` will automatically install and enable `nix-zsh-compeletions`.
+Setting `programs.zsh.enable = true` in `/etc/nixos/configuration.nix` will automatically install and enable `nix-zsh-compeletions`.
 
 Oh-My-ZSH Installation
 ----------------------

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -510,6 +510,10 @@ __nix_common_nixos_rebuild=(
     '*--option[set Nix configuration option]:options:_nix_options:value:_nix_options_value'
 )
 
+__nix_common_nixos_build_vms=(
+    '*--option[set Nix configuration option]:options:_nix_options:value:_nix_options_value'
+)
+
 __nix_common_store_opts=(
     '--add-root[register result as a root of the garbage collector]:path (Hint /nix/var/nix/gcroots):_path_files -/'
     '--indirect[store gc root outside GC roots directory]'

--- a/_nixos-build-vms
+++ b/_nixos-build-vms
@@ -4,6 +4,8 @@
 _nix-common-options
 
 _arguments \
+  $__nix_common_nixos_build_vms \
   '--show-trace[Show a trace of the output]'\
   "--no-out-link[Do not create a 'result' symlink]"\
+  "--help[Show help]"\
   '1:Network Nix Expression:_nix_complete_dotnix_files'


### PR DESCRIPTION
The `nixos-build-vms` script supports `--option` since
NixOS/nixpkgs#55121. Also added completions for {-h,--help}.