### PR TITLE
prompt_nix_shell_precmd: check for IN_NIX_RUN

### DIFF
--- a/nix-zsh-completions.plugin.zsh
+++ b/nix-zsh-completions.plugin.zsh
@@ -5,11 +5,16 @@ alias ni='nix-env -iA'
 alias ns='nix-env -qaP'
 
 function prompt_nix_shell_precmd {
-  if [[ -n ${IN_NIX_SHELL} && ${IN_NIX_SHELL} != "0" ]] then
+  if [[ -n ${IN_NIX_SHELL} && ${IN_NIX_SHELL} != "0" || ${IN_NIX_RUN} && ${IN_NIX_RUN} != "0" ]]; then
     if [[ -n ${IN_WHICH_NIX_SHELL} ]] then
       NIX_SHELL_NAME=": ${IN_WHICH_NIX_SHELL}"
     fi
-    NIX_PROMPT="%F{8}[%F{3}nix-shell${NIX_SHELL_NAME}%F{8}]%f"
+    if [[ -n ${IN_NIX_SHELL} && ${IN_NIX_SHELL} != "0" ]]; then
+      NAME="nix-shell"
+    else
+      NAME="nix-run"
+    fi
+    NIX_PROMPT="%F{8}[%F{3}${NAME}${NIX_SHELL_NAME}%F{8}]%f"
     if [[ $PROMPT != *"$NIX_PROMPT"* ]] then
       PROMPT="$NIX_PROMPT $PROMPT"
     fi


### PR DESCRIPTION
Since Nix 2.0 there's `nix run` which serves as replacement for
`nix-shell -p` and is detectable with the environment variable
IN_NIX_RUN.

This patch prefixes a ZSH session started by `nix run` with `[nix-run]`.