### PR TITLE
nixos-option: Complete custom modules as well

### DIFF
--- a/_nixos-option
+++ b/_nixos-option
@@ -3,11 +3,17 @@
 _nix-common-options # import _nix_attr_paths etc.
 
 _nixos-option-opts() {
+    local mods=
+    if [[ -n "$NIX_PATH" && "$NIX_PATH" =~ "nixos-config=" ]]; then
+        mods="(import <nixos-config>)"
+    fi
     local options='
       with import <nixpkgs/lib>;
       filterAttrsRecursive
         (k: _: substring 0 1 k != "_")
-        (evalModules { modules = import <nixpkgs/nixos/modules/module-list.nix>; }).options
+        (evalModules {
+          modules = import <nixpkgs/nixos/modules/module-list.nix> ++ [ '"$mods"' ];
+        }).options
     '
 
     _nix_attr_paths $options


### PR DESCRIPTION
Until now `_nixos-option` simply includes `module-list.nix` from
`<nixpkgs>` which contains all upstreamed modules. This won't work with
custom modules that are used in the current `<nixos-config>`. By
evaluating `<nixos-config>` (if available) all remaining modules will be
taken into account as well.