### PR TITLE
Complete missing options for `nixos-container create` and `nixos-container update`

### DIFF
--- a/_nixos-container
+++ b/_nixos-container
@@ -35,15 +35,22 @@ fi
 
 local _container_name='1:Container Name:_containers';
 local _container_config='--config[Config]:Config:( )';
+local _container_file='--config-file[Path to the container config file]:Path:_files';
 
 case "$words[1]" in
   create)
     _arguments\
       $_container_name\
       $_container_config\
+      $_container_file\
       '--system-path[System path]:Path:_files'\
       '--ensure-unique-name[Avoid name conflicts with other containers]'\
-      '--auto-start[Start the container immediately]'
+      '--auto-start[Start the container immediately]'\
+      '--nixos-path[Path to <nixpkgs/nixos>]:Path:_files'\
+      '--host-address[Host IP of the veth interface]:host address:'\
+      '--local-address[IPv4 address assined to the interface in the container]:local address:'\
+      '--bridge[Put the host-side of the veth-pair into the named bridge]:Bridge interface'\
+      '--port[Port forwarding]:port forwarding'
     ;;
   run)
     # TODO: There are a few more arguments in this case
@@ -53,7 +60,8 @@ case "$words[1]" in
   update)
     _arguments\
       $_container_name\
-      $_container_config
+      $_container_config\
+      $_container_file
     ;;
   destroy|start|stop|status|login|root-login|show-ip|show-host-key)
     _arguments\


### PR DESCRIPTION
Adds `--config-file` for `create` and `update`, adds several new options for new containers.