### PR TITLE
nix run -c: complete command names and arguments

### DIFF
--- a/_nix
+++ b/_nix
@@ -130,6 +130,8 @@ if [[ $command_lookup[$cmd] == 1 ]]; then
             # Handle `run --keep/--unset` manually as there's ambiguity the NAME argument
             if [[ $cmd == run && -z ${option:#(-k|--keep|-u|--unset)} ]]; then
                 command_options+=("*${option}[$description]:Environment Variable:_parameters")
+            elif [[ $cmd = run && $option == (-c|--command) ]]; then
+                command_options+=("${option}[$description]:command: _nix_run_command_names:*::args: _normal")
             elif [[ "$cmd" == add-to-store \
                         && "$option" == (-n|--name) ]]; then
                 # Another <NAME> ambiguity
@@ -234,7 +236,7 @@ case "${context%%-*} $state" in
         return
         ;;
     'option COMMAND')
-        _command_names
+        _command_names -e
         return
         ;;
     'option ARGS')

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -473,6 +473,57 @@ _nix_options_value () {
     esac
 }
 
+_nix_run_command_names () {
+    local cmd chan
+
+    if (( ${+commands[sqlite3]} )); then
+        # Extract the channels from NIX_PATH and -I/--include
+        # Add -I/--include afterwards, so they will shadow the NIX_PATH
+        local -a nix_path=(
+            ${(s.:.)NIX_PATH}
+            ${(s.:.)opt_args[-I]}
+            ${(s.:.)opt_args[--include]}
+        )
+
+        # channels: key - channel name, value - path to channel
+        local -A channels
+        for chan in $nix_path; do
+            if [[ $chan = *=* ]]; then
+                # name=path
+                channels[${chan%%=*}]=${chan#*=}
+            else
+                # path to directory with channels
+                for chan in $chan/*(-/); do
+                    channels[$chan:t]=$chan
+                done
+            fi
+        done
+
+        # pkg_cmds is list of commands inside packages
+        # This is an associative array to avoid duplicates.
+        local -A pkg_cmds
+        for chan in ${(k)channels}; do
+            # Extract args with prefix "$chan."
+            local -a pkgs=( "${${(M)words[@]:#"$chan".*}[@]##"$chan".}" )
+            (( ${#pkgs} )) || continue
+
+            local db=${channels[$chan]}/programs.sqlite
+            [ -f "$db" ] || continue
+
+            pkgs=( "'${^pkgs[@]//\'/''}'" ) # SQL-quote
+            local query="SELECT name FROM programs WHERE package IN (${(j:,:)pkgs})"
+
+            for cmd in $(sqlite3 "$db" "$query"); do
+                pkg_cmds[$cmd]=
+            done
+        done
+
+        compadd -X 'Package commands' -- ${(k)pkg_cmds}
+    fi
+
+    _command_names -e -X 'All commands'
+}
+
 ## Common options
 
 # Used in: nix-build, nix-env, nix-instantiate, nix-shell, nixops


### PR DESCRIPTION
* Complete command names from `programs.sqlite` database.
  ```
  $ nix run nixpkgs.cowsay -c ⭾
  Package commands
  cowsay                              cowthink
  All commands
  \[                                  mkfs.ext4
  2to3                                mkfs.fat
  ...
  ```

* Complete command arguments.
  E.g. `nix run nixpkgs.cowsay -c cowsay -⭾` will show you cowsay-related completions.

* Small fix: use `_command_names -e` instead of `_command_names`. This will filter out shell aliases, shell functions, etc.
