### PR TITLE
[WIP] Nix 3.0 (+flakes) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,22 @@ ZSH Completions Tutorial
 ------------------------
 
 [zsh-completions-howto](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org)
+
+Hacking
+-------
+
+When working on this module in an active `zsh` session you can test your changes
+like this:
+
+```
+$ fpath=(`pwd` $fpath)
+$ compinit
+```
+
+And reload after each change you made:
+```
+$ unfunction _nix && compinit
+```
+
+Instead of `_nix` you can also `unfunction` any other completion such as `_nix-build`, `_nix-shell`
+and so on.

--- a/_nix
+++ b/_nix
@@ -50,6 +50,8 @@ for option_description in $common_options_descriptions; do
     for option in $option_group; do
         if [[ "$option" == "--option" ]]; then
             common_options+=("*${option}[$description]:option:->nixoption:value:->nixoptionvalue")
+        elif  [[ "$option" == "--log-format" ]]; then
+            common_options+=('--log-format[format of log output]:format:_nix_log_formats')
         else
             # Default to mutually exclusive non-repeatable options
             common_options+=("($option_group)"$option"[$description]"$ACTIONS)
@@ -59,6 +61,7 @@ done
 
 # The --store option is undocumented for some reason
 common_options+=("--store[Select a nix store]:Store:->STORE-URI")
+common_options+=('--experimental-features[Which Features to enable]:features:_nix_exp_feat')
 
 local -a main_commands
 # Extract the commands with descriptions

--- a/_nix
+++ b/_nix
@@ -37,8 +37,8 @@ local option_description= option=
 for option_description in $common_options_descriptions; do
     local description=${option_description/(*  )/}
     local option_spec=${option_description%$description}
-    local -a option_group=(${=option_spec//(<*|,)/})
-    local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|<|>)/})
+    local -a option_group=(${=option_spec//($'\e\[3m'*|,)/})
+    local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|$'\e\[3m'|$'\e\[0m')/})
 
     local ACTIONS=""
     for arg in $option_args; do
@@ -92,7 +92,7 @@ if [[ $command_lookup[$cmd] == 1 ]]; then
     local -a help=(${(f)"$(nix $cmd --help)"})
     # Extract an array describing the possible arguments to the command eg.
     # (NAR PATH) for cat-nar or (INSTALLABLES) for run
-    local -a args=(${=help[1]//(*<FLAGS>|.|<|>)/})
+    local -a args=(${=${help[1]//$'\e\[1m'Usage:$'\e\[0m'}//(*FLAGS|.|$'\e\[3m'|$'\e\[0m')/})
     # And add the appropriate _argument spec
     local arg
     for arg in $args; do
@@ -115,9 +115,9 @@ if [[ $command_lookup[$cmd] == 1 ]]; then
         local option_spec=${option_description%$description}
 
         # Extract the options by stripping everything starting at '<' (and ',')
-        local -a option_group=(${=option_spec//(<*|,)/})
+        local -a option_group=(${=option_spec//($'\e\[3m'*|,)/})
         # Extract any arguments, by stripping the options (and <|>)
-        local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|<|>)/})
+        local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|$'\e\[3m'|$'\e\[0m')/})
 
         local ACTIONS=""
         for arg in $option_args; do

--- a/_nix
+++ b/_nix
@@ -23,104 +23,23 @@ _nix-common-options
 
 setopt extendedglob
 
-local context state state_descr line
-typeset -A opt_args
-
 type nix &> /dev/null || return
 
-local -a top_help=(${(f)"$(nix --help 2>/dev/null)"})
+function _nix_cmd_dispatch_comp {
+    local context state state_descr line
+    typeset -A opt_args
 
-local -a common_options
-# See per command flag handling for comments
-local common_options_descriptions=(${top_help:#^(  -*|  ??? -*)})
-local option_description= option=
-for option_description in $common_options_descriptions; do
-    local description=${option_description/(*  )/}
-    local option_spec=${option_description%$description}
-    local -a option_group=(${=option_spec//($'\e\[3m'*|,)/})
-    local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|$'\e\[3m'|$'\e\[0m')/})
+    local subcmd="${1:-}"
+    local -a top_help=(${(f)"$(nix $subcmd --help 2>/dev/null)"})
 
-    local ACTIONS=""
-    for arg in $option_args; do
-        # Prefix with ':*' if $arg ends in 'S', ie. is plural
-        local plural="${${(M)arg:#*S}:+:*}"
-        ACTIONS+="$plural:$arg:->$arg"
-    done
-
-    for option in $option_group; do
-        if [[ "$option" == "--option" ]]; then
-            common_options+=("*${option}[$description]:option:->nixoption:value:->nixoptionvalue")
-        elif  [[ "$option" == "--log-format" ]]; then
-            common_options+=('--log-format[format of log output]:format:_nix_log_formats')
-        else
-            # Default to mutually exclusive non-repeatable options
-            common_options+=("($option_group)"$option"[$description]"$ACTIONS)
-        fi
-    done
-done
-
-# The --store option is undocumented for some reason
-common_options+=("--store[Select a nix store]:Store:->STORE-URI")
-common_options+=('--experimental-features[Which Features to enable]:features:_nix_exp_feat')
-
-local -a main_commands
-# Extract the commands with descriptions
-# like ('command:some description' 'run:run some stuff'):
-#
-# Split the help output on newlines, and remove all lines which doesn't start
-# with two spaces and a lower case character,
-main_commands=(${top_help:#^(  [a-z]*)})
-# Strip the leading spaces
-main_commands=(${main_commands/#  /})
-# And replace the whitespace separating the command and description with ':'
-main_commands=(${main_commands/  ##/:})
-
-# Add commands to an associative array for easy lookup
-local -A command_lookup
-local command_description
-for command_description in $main_commands; {
-    local command=${command_description%%\:*}
-    command_lookup[$command]=1
-}
-
-local -a command_options=()
-local -a command_arguments=()
-# Setup the correct command_arguments and command_options depending on which
-# command we've typed
-_arguments '*: :->subcmd' && return 0
-local cmd=${line[1]}
-
-# Check if we're in a valid command
-if [[ $command_lookup[$cmd] == 1 ]]; then
-    local -a help=(${(f)"$(nix $cmd --help 2>/dev/null)"})
-    # Extract an array describing the possible arguments to the command eg.
-    # (NAR PATH) for cat-nar or (INSTALLABLES) for run
-    local -a args=(${=${help[1]//$'\e\[1m'Usage:$'\e\[0m'}//(*FLAGS|.|$'\e\[3m'|$'\e\[0m')/})
-    # And add the appropriate _argument spec
-    local arg
-    for arg in $args; do
-        local _arg=${arg%?}
-        # Prefix * if $arg ends in 'S', ie. is plural
-        local plural="${${(M)_arg:#*S}:+*}"
-        command_arguments+=("$plural:$_arg:->$_arg")
-    done
-
-    # Extract the lines containing the option descriptions
-    local -a option_descriptions
-    option_descriptions=(${help:#^(  -*|  ??? -*)})
-
+    local -a common_options
+    # See per command flag handling for comments
+    local common_options_descriptions=(${top_help:#^(  -*|  ??? -*)})
     local option_description= option=
-    for option_description in $option_descriptions; do
-
-        # Extract the description by stripping everything up to the the last
-        # two consecutive spaces
+    for option_description in $common_options_descriptions; do
         local description=${option_description/(*  )/}
-        # Remove the description from the help line
         local option_spec=${option_description%$description}
-
-        # Extract the options by stripping everything starting at '<' (and ',')
         local -a option_group=(${=option_spec//($'\e\[3m'*|,)/})
-        # Extract any arguments, by stripping the options (and <|>)
         local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|$'\e\[3m'|$'\e\[0m')/})
 
         local ACTIONS=""
@@ -131,140 +50,233 @@ if [[ $command_lookup[$cmd] == 1 ]]; then
         done
 
         for option in $option_group; do
-            # Handle `run --keep/--unset` manually as there's ambiguity the NAME argument
-            if [[ $cmd == run && -z ${option:#(-k|--keep|-u|--unset)} ]]; then
-                command_options+=("*${option}[$description]:Environment Variable:_parameters")
-            elif [[ $cmd = run && $option == (-c|--command) ]]; then
-                command_options+=("${option}[$description]:command: _nix_run_command_names:*::args: _normal")
-            elif [[ "$cmd" == add-to-store \
-                        && "$option" == (-n|--name) ]]; then
-                # Another <NAME> ambiguity
-                command_options+=("($option_group)"$option"[$description]:->store-name")
-            elif [[ $option == (-I|--include) ]]; then
-                # Special handling of --include due to type ambiguity
-                command_options+=("*${option}[$description]:Includes:->INCLUDE")
-            elif [[ -z ${option:#(--arg|--argstr|-f|--file)} ]]; then
-                # Repeatable options
-                command_options+=("*${option}[$description]"$ACTIONS)
-                if [[ $option == -f ]]; then
-                    # -f. is accepted shorthand for -f .
-                    command_options+="-f.[${description/FILE/\./default.nix}]"
-                fi
+            if [[ "$option" == "--option" ]]; then
+                common_options+=("*${option}[$description]:option:->nixoption:value:->nixoptionvalue")
+            elif  [[ "$option" == "--log-format" ]]; then
+                common_options+=('--log-format[format of log output]:format:_nix_log_formats')
             else
                 # Default to mutually exclusive non-repeatable options
-                command_options+=("($option_group)"$option"[$description]"$ACTIONS)
+                common_options+=("($option_group)"$option"[$description]"$ACTIONS)
             fi
         done
     done
-fi
 
-_arguments -s \
-           ":Command: _describe -t main_commands Command main_commands"\
-           $command_arguments \
-           $common_options \
-           $command_options && return 0
+    # The --store option is undocumented for some reason
+    common_options+=("--store[Select a nix store]:Store:->STORE-URI")
+    common_options+=('--experimental-features[Which Features to enable]:features:_nix_exp_feat')
 
-# Handle arguments to commands and options
-case "${context%%-*} $state" in
-    'argument '(INSTALLABLES|INSTALLABLE|PACKAGE|DEPENDENCY))
-        # Complete attribute paths and files starting with either "/" or "./"
+    local -a main_commands
+    # Extract the commands with descriptions
+    # like ('command:some description' 'run:run some stuff'):
+    #
+    # Split the help output on newlines, and remove all lines which doesn't start
+    # with two spaces and a lower case character,
+    main_commands=(${top_help:#^(  [a-z]*)})
+    # Strip the leading spaces
+    main_commands=(${main_commands/#  /})
+    # And replace the whitespace separating the command and description with ':'
+    main_commands=(${main_commands/  ##/:})
 
-        # We need to prefix relative paths with ./ so nix will evaluate it as a
-        # path
-        local prefix='-P ./'
-        local current_word=$words[$CURRENT]
-        # When referencing an absolute path we can't prefix with ./
-        if [[ -z ${current_word:##(/*|\~/*)} && -n $current_word ]]; then
-            prefix=""
-        fi
-        _alternative \
-            'path:Attribute path: _nix_complete_attr_paths' \
-            "file:File path to package:_files ${prefix}"
-        return
-        ;;
-    'argument '(PATH|PATHS))
-        _files
-        return
-        ;;
-    'argument FILES')
-        _nix_complete_dotnix_files
-        return
-        ;;
-    'argument NAR')
-        _files -X "NAR"
-        return
-        ;;
-    'argument REGEX')
-        _message 'Regex to search for'
-        return
-        ;;
-    'argument STRINGS')
-        _message 'HASH to convert to a different base'
-        return
-        ;;
-    'option PROFILE-DIR')
-        _nix_profiles
-        return
-        ;;
-    'option NAME')
-        _nix_complete_function_arg
-        return
-        ;;
-    'option EXPR')
-        _message 'Expression argument'
-        return
-        ;;
-    'option STRING')
-        _message 'String argument'
-        return
-        ;;
-    'option STORE-URI')
-        local -a others=(
-            'local:Use /nix/store'
-            'remote:Go via the Nix daemon'
-            'https\://:HTTPS'
-            's3\://:S3 binary cache'
-            'ssh\://:Nix store over ssh')
-        _alternative \
-            'file:Use a chroot store:_directories' \
-            'url:Other: _describe "URLS and special options" others' \
-            'cache:Local binary cache (adds file url prefix):_path_files -P "file://" -/'
-        return
-        ;;
-    'option FILE')
-        _nix_complete_dotnix_files
-        return
-        ;;
-    'option FILES'|'option PATH')
-        _files
-        return
-        ;;
-    'option COMMAND')
-        _command_names -e
-        return
-        ;;
-    'option ARGS')
-        _message 'Arguments to command'
-        return
-        ;;
-    'option TYPE')
-        _values 'Hash type' md5 sha1 sha256 sha512
-        return
-        ;;
-    'option INCLUDE')
-        # --include <PATH> completion
-        _nix_complete_includes
-        return
-        ;;
-    'option nixoption')
-        _nix_options
-        return
-        ;;
-    'option nixoptionvalue')
-        _nix_options_value
-        return
-        ;;
-    *)
-        # Fallback to argument name description
-        _message "$state_descr"
-esac
+    # Add commands to an associative array for easy lookup
+    local -A command_lookup
+    local command_description
+    for command_description in $main_commands; {
+        local command=${command_description%%\:*}
+        command_lookup[$command]=1
+    }
+
+    local -a command_options=()
+    local -a command_arguments=()
+    # Setup the correct command_arguments and command_options depending on which
+    # command we've typed
+    _arguments '*: :->subcmd' && return 0
+    local cmd=${line[1]}
+    [ -n "$subcmd" ] && cmd=${line[2]}
+
+    # Check if we're in a valid command
+    if [[ $command_lookup[$cmd] == 1 ]]; then
+        local -a help=(${(f)"$(nix $subcmd $cmd --help 2>/dev/null)"})
+        # Extract an array describing the possible arguments to the command eg.
+        # (NAR PATH) for cat-nar or (INSTALLABLES) for run
+        local -a args=(${=${help[1]//$'\e\[1m'Usage:$'\e\[0m'}//(*FLAGS|.|$'\e\[3m'|$'\e\[0m')/})
+        # And add the appropriate _argument spec
+        local arg
+        for arg in $args; do
+            local _arg=${arg%?}
+            # Prefix * if $arg ends in 'S', ie. is plural
+            local plural="${${(M)_arg:#*S}:+*}"
+            command_arguments+=("$plural:$_arg:->$_arg")
+        done
+
+        # Extract the lines containing the option descriptions
+        local -a option_descriptions
+        option_descriptions=(${help:#^(  -*|  ??? -*)})
+
+        local option_description= option=
+        for option_description in $option_descriptions; do
+
+            # Extract the description by stripping everything up to the the last
+            # two consecutive spaces
+            local description=${option_description/(*  )/}
+            # Remove the description from the help line
+            local option_spec=${option_description%$description}
+
+            # Extract the options by stripping everything starting at '<' (and ',')
+            local -a option_group=(${=option_spec//($'\e\[3m'*|,)/})
+            # Extract any arguments, by stripping the options (and <|>)
+            local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|$'\e\[3m'|$'\e\[0m')/})
+
+            local ACTIONS=""
+            for arg in $option_args; do
+                # Prefix with ':*' if $arg ends in 'S', ie. is plural
+                local plural="${${(M)arg:#*S}:+:*}"
+                ACTIONS+="$plural:$arg:->$arg"
+            done
+
+            for option in $option_group; do
+                # Handle `run --keep/--unset` manually as there's ambiguity the NAME argument
+                if [[ $cmd == run && -z ${option:#(-k|--keep|-u|--unset)} ]]; then
+                    command_options+=("*${option}[$description]:Environment Variable:_parameters")
+                elif [[ $cmd = run && $option == (-c|--command) ]]; then
+                    command_options+=("${option}[$description]:command: _nix_run_command_names:*::args: _normal")
+                elif [[ "$cmd" == add-to-store \
+                            && "$option" == (-n|--name) ]]; then
+                    # Another <NAME> ambiguity
+                    command_options+=("($option_group)"$option"[$description]:->store-name")
+                elif [[ $option == (-I|--include) ]]; then
+                    # Special handling of --include due to type ambiguity
+                    command_options+=("*${option}[$description]:Includes:->INCLUDE")
+                elif [[ -z ${option:#(--arg|--argstr|-f|--file)} ]]; then
+                    # Repeatable options
+                    command_options+=("*${option}[$description]"$ACTIONS)
+                    if [[ $option == -f ]]; then
+                        # -f. is accepted shorthand for -f .
+                        command_options+="-f.[${description/FILE/\./default.nix}]"
+                    fi
+                else
+                    # Default to mutually exclusive non-repeatable options
+                    command_options+=("($option_group)"$option"[$description]"$ACTIONS)
+                fi
+            done
+        done
+    fi
+
+    [ -n "$subcmd" ] && _describe -t main_commands Command main_commands && return 0
+    _arguments -s \
+               ":Command: _describe -t main_commands Command main_commands"\
+               $command_arguments \
+               $common_options \
+               $command_options && return 0
+
+    # Handle arguments to commands and options
+    case "${context%%-*} $state" in
+        'argument '(INSTALLABLES|INSTALLABLE|PACKAGE|DEPENDENCY))
+            # Complete attribute paths and files starting with either "/" or "./"
+
+            # We need to prefix relative paths with ./ so nix will evaluate it as a
+            # path
+            local prefix='-P ./'
+            local current_word=$words[$CURRENT]
+            # When referencing an absolute path we can't prefix with ./
+            if [[ -z ${current_word:##(/*|\~/*)} && -n $current_word ]]; then
+                prefix=""
+            fi
+            _alternative \
+                'path:Attribute path: _nix_complete_attr_paths' \
+                "file:File path to package:_files ${prefix}"
+            return
+            ;;
+        'argument '(PATH|PATHS))
+            _files
+            return
+            ;;
+        'argument ARG')
+            cmd_name=$words[$CURRENT-1]
+            _nix_cmd_dispatch_comp "$cmd_name"
+            return
+            ;;
+        'argument FILES')
+            _nix_complete_dotnix_files
+            return
+            ;;
+        'argument NAR')
+            _files -X "NAR"
+            return
+            ;;
+        'argument REGEX')
+            _message 'Regex to search for'
+            return
+            ;;
+        'argument STRINGS')
+            _message 'HASH to convert to a different base'
+            return
+            ;;
+        'option PROFILE-DIR')
+            _nix_profiles
+            return
+            ;;
+        'option NAME')
+            _nix_complete_function_arg
+            return
+            ;;
+        'option EXPR')
+            _message 'Expression argument'
+            return
+            ;;
+        'option STRING')
+            _message 'String argument'
+            return
+            ;;
+        'option STORE-URI')
+            local -a others=(
+                'local:Use /nix/store'
+                'remote:Go via the Nix daemon'
+                'https\://:HTTPS'
+                's3\://:S3 binary cache'
+                'ssh\://:Nix store over ssh')
+            _alternative \
+                'file:Use a chroot store:_directories' \
+                'url:Other: _describe "URLS and special options" others' \
+                'cache:Local binary cache (adds file url prefix):_path_files -P "file://" -/'
+            return
+            ;;
+        'option FILE')
+            _nix_complete_dotnix_files
+            return
+            ;;
+        'option FILES'|'option PATH')
+            _files
+            return
+            ;;
+        'option COMMAND')
+            _command_names -e
+            return
+            ;;
+        'option ARGS')
+            _message 'Arguments to command'
+            return
+            ;;
+        'option TYPE')
+            _values 'Hash type' md5 sha1 sha256 sha512
+            return
+            ;;
+        'option INCLUDE')
+            # --include <PATH> completion
+            _nix_complete_includes
+            return
+            ;;
+        'option nixoption')
+            _nix_options
+            return
+            ;;
+        'option nixoptionvalue')
+            _nix_options_value
+            return
+            ;;
+        *)
+            # Fallback to argument name description
+            _message "$state_descr"
+    esac
+}
+
+_nix_cmd_dispatch_comp

--- a/_nix
+++ b/_nix
@@ -5,7 +5,8 @@
 
 # There's four different types of options and arguments which is passed to _arguments:
 #
-# 1. The main commands which we get from nix --help
+# 1. The main commands which we get from nix --help or a subcommand accepting commands
+#    such as nix flake --help
 #
 # 2. The common options which are hardcoded for the moment
 #
@@ -29,8 +30,45 @@ function _nix_cmd_dispatch_comp {
     local context state state_descr line
     typeset -A opt_args
 
-    local subcmd="${1:-}"
-    local -a top_help=(${(f)"$(nix $subcmd --help 2>/dev/null)"})
+    # This is a ternary value which indicates whether a subcommand of a subcommand
+    # (e.g. nix flake <COMMAND>) is about to get completed. It will be assigned to one of
+    # the following three states:
+    # * -1: No subcommand-completion needs to happen.
+    # *  0: No subcommand completion will happen since a subcommand of a subcommand that
+    #       doesn't have further subcommands needs to be completed.
+    # *  1: We are in a subcommand and want to complete the available commands such as
+    #       nix flake update.
+    local has_subcmd=-1
+
+    # Extract the main commands of `nix` or a "recursive" subcommand such as `nix flake`.
+    # For this purpose, the current command (`$words`) gets shortened until there's only a
+    # command left that accepts subcommands.
+    #
+    # This is needed to either complete subcommands or to extract the information for
+    # the currently active command to complete (see above comment for the general workflow
+    # of this completion).
+    local -a top_help
+    local words_p="${words[@]}"
+    while [ -z "${top_help}" ]; do
+        local -a result=(${(f)"$(${=words_p:-nix} --help 2>/dev/null)"})
+
+        # Check if the current helptext is displayed for a command accepting subcommands.
+        if grep -q $'\e'"\[1m.*commands:"$'\e'"\[0m" <<< "$result"; then
+            if [ "${#${=$(sed -re 's/-[^ ]+//g' <<< "$words_p")}}" -gt 1 ] && [ $has_subcmd -eq -1 ]; then
+                has_subcmd=1
+            fi
+            top_help=($result)
+            break
+        fi
+
+        # If a shortened version of `$words` is the main-command, no subcommand will
+        # be completed. Otherwise e.g. `nix flake update` would still complete subcommands
+        # for `nix flake`.
+        if [ -n "${result}" ]; then
+            has_subcmd=0
+        fi
+        words_p="$(sed -re "s/(.*)[ ]+\$/\1/" -re "s/(.*) [^ ]+\$/\1/" <<< "$words_p")"
+    done
 
     local -a common_options
     # See per command flag handling for comments
@@ -90,12 +128,22 @@ function _nix_cmd_dispatch_comp {
     # Setup the correct command_arguments and command_options depending on which
     # command we've typed
     _arguments '*: :->subcmd' && return 0
-    local cmd=${line[1]}
-    [ -n "$subcmd" ] && cmd=${line[2]}
+
+    # Extract the command we're about to complete. The command must be the first string
+    # after the current (sub)command (which can be e.g. `nix` or `nix flake`) that is not
+    # an option.
+    local cmd
+    for i in "${=${words[@]}/$words_p/}"; do
+        if [[ "$i" == -* ]] || [[ -z "$i" ]]; then
+            continue
+        fi
+        cmd="$i"
+        break
+    done
 
     # Check if we're in a valid command
     if [[ $command_lookup[$cmd] == 1 ]]; then
-        local -a help=(${(f)"$(nix $subcmd $cmd --help 2>/dev/null)"})
+        local -a help=(${(f)"$(${=words_p} $cmd --help 2>/dev/null)"})
         # Extract an array describing the possible arguments to the command eg.
         # (NAR PATH) for cat-nar or (INSTALLABLES) for run
         local -a args=(${=${help[1]//$'\e\[1m'Usage:$'\e\[0m'}//(*FLAGS|.|$'\e\[3m'|$'\e\[0m')/})
@@ -121,9 +169,9 @@ function _nix_cmd_dispatch_comp {
             # Remove the description from the help line
             local option_spec=${option_description%$description}
 
-            # Extract the options by stripping everything starting at '<' (and ',')
+            # Extract the options by stripping everything starting at '\e[3m' (and ',')
             local -a option_group=(${=option_spec//($'\e\[3m'*|,)/})
-            # Extract any arguments, by stripping the options (and <|>)
+            # Extract any arguments, by stripping the options (and \e[3m|\e[0m)
             local -a option_args=(${=option_spec//(*$option_group[${#option_group}]|$'\e\[3m'|$'\e\[0m')/})
 
             local ACTIONS=""
@@ -161,7 +209,9 @@ function _nix_cmd_dispatch_comp {
         done
     fi
 
-    [ -n "$subcmd" ] && _describe -t main_commands Command main_commands && return 0
+    if [ $has_subcmd -eq 1 ]; then
+        _describe -t main_commands Command main_commands && return 0
+    fi
     _arguments -s \
                ":Command: _describe -t main_commands Command main_commands"\
                $command_arguments \
@@ -170,6 +220,10 @@ function _nix_cmd_dispatch_comp {
 
     # Handle arguments to commands and options
     case "${context%%-*} $state" in
+        'argument FLAKE-URL')
+            _message "Not implemented yet"
+            return
+            ;;
         'argument '(INSTALLABLES|INSTALLABLE|PACKAGE|DEPENDENCY))
             # Complete attribute paths and files starting with either "/" or "./"
 
@@ -191,8 +245,7 @@ function _nix_cmd_dispatch_comp {
             return
             ;;
         'argument ARG')
-            cmd_name=$words[$CURRENT-1]
-            _nix_cmd_dispatch_comp "$cmd_name"
+            _nix_cmd_dispatch_comp
             return
             ;;
         'argument FILES')

--- a/_nix
+++ b/_nix
@@ -96,9 +96,10 @@ if [[ $command_lookup[$cmd] == 1 ]]; then
     # And add the appropriate _argument spec
     local arg
     for arg in $args; do
+        local _arg=${arg%?}
         # Prefix * if $arg ends in 'S', ie. is plural
-        local plural="${${(M)arg:#*S}:+*}"
-        command_arguments+=("$plural:$arg:->$arg")
+        local plural="${${(M)_arg:#*S}:+*}"
+        command_arguments+=("$plural:$_arg:->$_arg")
     done
 
     # Extract the lines containing the option descriptions

--- a/_nix
+++ b/_nix
@@ -28,7 +28,7 @@ typeset -A opt_args
 
 type nix &> /dev/null || return
 
-local -a top_help=(${(f)"$(nix --help)"})
+local -a top_help=(${(f)"$(nix --help 2>/dev/null)"})
 
 local -a common_options
 # See per command flag handling for comments
@@ -89,7 +89,7 @@ local cmd=${line[1]}
 
 # Check if we're in a valid command
 if [[ $command_lookup[$cmd] == 1 ]]; then
-    local -a help=(${(f)"$(nix $cmd --help)"})
+    local -a help=(${(f)"$(nix $cmd --help 2>/dev/null)"})
     # Extract an array describing the possible arguments to the command eg.
     # (NAR PATH) for cat-nar or (INSTALLABLES) for run
     local -a args=(${=${help[1]//$'\e\[1m'Usage:$'\e\[0m'}//(*FLAGS|.|$'\e\[3m'|$'\e\[0m')/})

--- a/_nix
+++ b/_nix
@@ -212,7 +212,17 @@ function _nix_cmd_dispatch_comp {
     if [ $has_subcmd -eq 1 ]; then
         _describe -t main_commands Command main_commands && return 0
     fi
+
+    # Determine if a subcommand is completed in order to make sure that the
+    # proper positional argument is selected for completion.
+    local main=
+    local _words_p="$words_p "
+    if [ "${#${=_words_p}}" -gt 1 ]; then
+        main=":Main: "
+    fi
+
     _arguments -s \
+               $main \
                ":Command: _describe -t main_commands Command main_commands"\
                $command_arguments \
                $common_options \
@@ -220,8 +230,19 @@ function _nix_cmd_dispatch_comp {
 
     # Handle arguments to commands and options
     case "${context%%-*} $state" in
-        'argument FLAKE-URL')
-            _message "Not implemented yet"
+        'argument FROM-URL')
+            local -a others=(
+                'github:GitHub Repository'
+                'gitlab:GitLab Repository'
+                'git:Git Repository'
+                'https\://:HTTPS')
+            _alternative \
+                'url:Other: _describe "URLS and special options" others' \
+                'path:Local path (adds path url prefix):_path_files -P "path://"'
+            return
+            ;;
+        'argument '(TO-URL|URL|FLAKE-URL))
+            _nix_complete_registry
             return
             ;;
         'argument '(INSTALLABLES|INSTALLABLE|PACKAGE|DEPENDENCY))

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -315,11 +315,19 @@ _nix_complete_attr_paths () {
                 names[$name]=1
             done
 
+            cmd_name=$words[$CURRENT-1]
+            attr_derefs=''
+            tpl='((n.@attr@ or {}).${builtins.currentSystem} or {})'
+            if [ "$cmd_name" = "run" ]; then
+              attr_derefs="${tpl/@attr@/apps}"
+            elif [[ "$cmd_name" =~ (build|shell|edit|log|verify|why-depends) ]]; then
+              attr_derefs="${tpl/@attr@/packages} // ${tpl/@attr@/legacyPackages}"
+            fi
             defexpr=$'{ '
             for name in ${(@k)names}; do
                 # nixos-config isn't useful or possible to complete
                 [[ $name == nixos-config ]] && continue
-                defexpr+="\"$name\" = builtins.getFlake \"${name}\"; "
+                defexpr+="\"$name\" = let n = builtins.getFlake \"${name}\"; in n // ${attr_derefs:-"{}"}; "
             done
             defexpr+=' }'
         fi

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -307,15 +307,7 @@ _nix_complete_attr_paths () {
 
         elif [[ $service == nix ]]; then
             sep="#"
-            # Add the names in an associative array to avoid duplicates
-            local -a channels=(${(f)"$(nix registry list 2>/dev/null)"})
-            local -A names
-            local channel name
-            for channel in $channels; do
-                name=${${channel#*flake:}// */}
-                names[$name]=1
-              done
-              names[.]=1
+            local -A names=( ${(@fkv)${(@Fs: :)$(_nix_registry_entries)}} )
 
             cmd_name=$words[$CURRENT-1]
             attr_derefs=''
@@ -338,6 +330,25 @@ _nix_complete_attr_paths () {
     if [[ $defexpr ]]; then
         _nix_attr_paths $defexpr $sep
     fi
+}
+
+_nix_complete_registry() {
+    local -A names=( ${(@fkv)${(@Fs: :)$(_nix_registry_entries)}} )
+    _values 'Entries' ${(@k)names}
+}
+
+function _nix_registry_entries() {
+    # Add the names in an associative array to avoid duplicates
+    local -a channels=(${(f)"$(nix registry list 2>/dev/null)"})
+    local -A names
+    local channel name
+    for channel in $channels; do
+        name=${${channel#*flake:}// */}
+        names[$name]=1
+    done
+    names[.]=1
+
+    echo "${(kv)names}"
 }
 
 function _nix_resolve_url () {

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -298,7 +298,7 @@ _nix_complete_attr_paths () {
         elif [[ $service == nix ]]; then
             sep="#"
             # Add the names in an associative array to avoid duplicates
-            local -a channels=(${(f)"$(nix registry list)"})
+            local -a channels=(${(f)"$(nix registry list 2>/dev/null)"})
             local -A names
             local channel name
             for channel in $channels; do
@@ -411,7 +411,7 @@ function _nix_complete_function_arg () {
         return
     fi
     local -a names
-    names=($(_nix_eval_stdin 2>&1 <<NIX_FILE
+    names=($(_nix_eval_stdin 2>/dev/null <<NIX_FILE
              if builtins.typeOf ($func) == "lambda" then
                 builtins.attrNames (builtins.functionArgs ($func))
              else
@@ -447,7 +447,7 @@ _nix_options () {
     local -a nix_options
     # Strip the header line, remove leading spaces and replace separating
     # whitespace with ':'
-    nix_options=(${${${${(f)"$(nix --help-config)"}:1:-1}/#  /}/  ##/:})
+    nix_options=(${${${${(f)"$(nix --help-config 2>/dev/null)"}:1:-1}/#  /}/  ##/:})
                    _describe -t nix_options "Option" nix_options
 }
 
@@ -456,7 +456,7 @@ _nix_options_value () {
     local OPTION=$words[$(($CURRENT - 1))]
     # Remove lines not starting with " $OPTION " and strip eveything up to the
     # last two consecutive spaces
-    local description=${${${(f)"$(nix --help-config)"}:#^(  $OPTION *)}/*  /}
+    local description=${${${(f)"$(nix --help-config 2>/dev/null)"}:#^(  $OPTION *)}/*  /}
     local -a values=()
     case "$description" in
         Whether*)

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -156,9 +156,10 @@ _nix_attr_paths () {
     fi
 
     local defexpr=$1
+    local sep=${2:-.}
     local attr_path=""
-    if [[ $cur == *.* ]]; then
-        attr_path=${cur%.*}
+    if [[ $cur == *${sep}* ]] || [[ $cur == *.* ]]; then
+        attr_path=${${cur//\\\#/.}%.*}
     fi
 
     # attr1.attr3 -> ("attr1" "attr2")
@@ -202,13 +203,14 @@ $result"
     local -a prefix=()
     if [[ -n $attr_path ]]; then
         for i in ${=attr_path//./ }; do
-            prefix+=("($i)" .)
+            prefix+=("($i)" $sep)
+            sep="."
         done
     fi
 
     local package=""
     _wanted package package "Attribute path" \
-            _sep_parts $prefix result \.
+            _sep_parts $prefix result ${sep//\./\.}
     return $?
 }
 
@@ -257,6 +259,7 @@ _nix_complete_attr_paths () {
 
     local defexpr=""
     local file=$(_nix_get_file_arg)
+    local sep="."
     if [[ "$file" ]]; then
         # Extract --arg and --argstr into $args
         local i=1 args="" name="" value=""
@@ -293,36 +296,28 @@ _nix_complete_attr_paths () {
             defexpr=$(_nix_gen_defexpr ~/.nix-defexpr)
 
         elif [[ $service == nix ]]; then
-            # Extract the channels from NIX_PATH and -I/--include
-            local -a channels=(${(s.:.)NIX_PATH})
-            # Add -I/--include afterwards, so they will shadow the NIX_PATH
-            channels+=(${(s.:.)opt_args[-I]})
-            channels+=(${(s.:.)opt_args[--include]})
-
+            sep="#"
             # Add the names in an associative array to avoid duplicates
+            local -a channels=(${(f)"$(nix registry list)"})
             local -A names
             local channel name
             for channel in $channels; do
-                name=${channel%%=*}
-                nix_path=${channel#*=}
-                if [[ $name != $channel ]]; then
-                    # Only add paths with a name, not sure how they work
-                    names[$name]=1
-                fi
+                name=${${channel#*flake:}// */}
+                names[$name]=1
             done
 
             defexpr=$'{ '
             for name in ${(@k)names}; do
                 # nixos-config isn't useful or possible to complete
                 [[ $name == nixos-config ]] && continue
-                defexpr+="$name = import <${name}>; "
+                defexpr+="\"$name\" = builtins.getFlake \"${name}\"; "
             done
             defexpr+=' }'
         fi
     fi
 
     if [[ $defexpr ]]; then
-        _nix_attr_paths $defexpr
+        _nix_attr_paths $defexpr $sep
     fi
 }
 

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -18,6 +18,15 @@ _nix_systems () {
         i686-cygwin x86_64-cygwin
 }
 
+_nix_log_formats() {
+  _values 'Formats' \
+    raw internal-json bar bar-with-logs
+}
+_nix_exp_feat() {
+  _values -s ' ' 'Formats' \
+    flakes nix-command recursive-nix ca-derivations ca-references
+}
+
 # Completion function to select an angle-bracket expression from the nix path
 # Assumptions: No '=' in the actual path components in NIX_PATH
 # TODO: Complete files in /some/path for expressions like <nixpkgs/pkgs/...>
@@ -589,6 +598,8 @@ __nix_common_opts=(
     '*--include[add a path to the list of locations used to look up <...> file names]:include path:_nix_complete_includes'
     '*--arg[argument to pass to the Nix function]:Name:_nix_complete_function_arg:Value: '
     '*--argstr[pass a string]:Name:_nix_complete_function_arg:String: '
+    '--log-format[Format of log output]:format:_nix_log_formats'
+    '--experimental-features[Which Features to enable]:features:_nix_exp_feat'
 )
 
 # Options for nix-store --realise, used by nix-build

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -161,7 +161,7 @@ _nix_attr_paths () {
     # Starting with '.' causes _sep_parts to complain, so exit early.
     # This also guards against error output when completion './files' with nix.
     if [[ $cur == .* ]]; then
-        return
+        cur="__nix_zsh_mark_current_flake__$cur"
     fi
 
     local defexpr=$1
@@ -175,6 +175,7 @@ _nix_attr_paths () {
     local -a paths=(${(s,.,)attr_path})
     # Add quotes in a second step to avoid ("") when empty
     paths=(${${paths/%/\"}/#/\"})
+    paths[1]="${paths[1]/__nix_zsh_mark_current_flake__/.}"
 
     # Auto call any functions in the attribute path. This isn't a language
     # feature, but done by nix when passing attributes on the command line.
@@ -212,7 +213,7 @@ $result"
     local -a prefix=()
     if [[ -n $attr_path ]]; then
         for i in ${=attr_path//./ }; do
-            prefix+=("($i)" $sep)
+            prefix+=("(${i/__nix_zsh_mark_current_flake__/.})" $sep)
             sep="."
         done
     fi
@@ -313,7 +314,8 @@ _nix_complete_attr_paths () {
             for channel in $channels; do
                 name=${${channel#*flake:}// */}
                 names[$name]=1
-            done
+              done
+              names[.]=1
 
             cmd_name=$words[$CURRENT-1]
             attr_derefs=''
@@ -327,7 +329,7 @@ _nix_complete_attr_paths () {
             for name in ${(@k)names}; do
                 # nixos-config isn't useful or possible to complete
                 [[ $name == nixos-config ]] && continue
-                defexpr+="\"$name\" = let n = builtins.getFlake \"${name}\"; in n // ${attr_derefs:-"{}"}; "
+                defexpr+="\"$name\" = let n = builtins.getFlake \"$(sed -e "s/^\.\$/${$(pwd)//\//\\/}/" <<< $name)\"; in n // ${attr_derefs:-"{}"}; "
             done
             defexpr+=' }'
         fi


### PR DESCRIPTION
:warning: **Caution:** *very* early (and probably broken) draft to support Nix 2.4 completion (with and without `flakes`-support).

###### Todo:

__Note:__ I recommend to review this commit-by-commit, unfortunately the diff grew a bit too much.

* [x] Optional arguments (declared as `PATH?`, see e.g. `nix add-to-store --help` for instance)
* [ ] New Flake CLI
  * [x] Local flakes (`nix build .#packages`)
  * [x] `nix flake` subcommands
  * [x] `nix flake cmd` cli options
  * [x] Support for flake registries (and `flake#attr`-expressions)
  * [x] Package-completion `nix shell nixpkgs#nixStabe` (currently only `nix shell nixpkgs#packages.x86_64-linux.nixStable` gets comleted).
  * [x] Completion for flake URLs
* [x] options/`--experimental-features`/`--log-format`
* [ ] backwards compat
* [ ] `prompt_nix_shell_setup` for `nix develop/shell/run`
* probably more

Refs #32 