### PR TITLE
Update channel list suggestion in _nix_complete_dotnix_files

### DIFF
--- a/_nix-common-options
+++ b/_nix-common-options
@@ -45,17 +45,26 @@ _nix_complete_dotnix_files () {
         "file:Local file:_path_files -g '*.nix(N) *(N-/)'" \
         'shortcuts:Shortcuts:_nix_shortcuts' \
         'channel:Channel:(channel:
-            channel:nixos-13.10           channel:nixos-16.09
-            channel:nixos-14.04           channel:nixos-16.09-small
-            channel:nixos-14.04-small     channel:nixos-17.03
-            channel:nixos-14.12           channel:nixos-17.03-small
-            channel:nixos-14.12-small     channel:nixos-17.09
-            channel:nixos-15.09           channel:nixos-17.09-small
-            channel:nixos-15.09-small     channel:nixos-unstable
-            channel:nixos-16.03           channel:nixos-unstable-small
-            channel:nixos-16.03-small     channel:nixpkgs-17.09-darwin
+            channel:nixos-13.10
+            channel:nixos-14.04           channel:nixos-14.04-small
+            channel:nixos-14.12           channel:nixos-14.12-small
+            channel:nixos-15.09           channel:nixos-15.09-small
+            channel:nixos-16.03           channel:nixos-16.03-small
+            channel:nixos-16.09           channel:nixos-16.09-small
+            channel:nixos-17.03           channel:nixos-17.03-small
+            channel:nixos-17.09           channel:nixos-17.09-small
             channel:nixos-18.03           channel:nixos-18.03-small
-            channel:nixos-16.03-testing   channel:nixpkgs-unstable)' \
+            channel:nixos-18.09           channel:nixos-18.09-small
+            channel:nixos-19.03           channel:nixos-19.03-small
+            channel:nixos-19.09           channel:nixos-19.09-small
+            channel:nixos-20.03           channel:nixos-20.03-small
+            channel:nixos-20.09           channel:nixos-20.09-small
+            channel:nixos-unstable        channel:nixos-unstable-small
+            channel:nixpkgs-17.09-darwin  channel:nixpkgs-18.03-darwin
+            channel:nixpkgs-18.09-darwin  channel:nixpkgs-19.03-darwin
+            channel:nixpkgs-19.09-darwin  channel:nixpkgs-20.03-darwin
+            channel:nixpkgs-20.09-darwin
+            channel:nixpkgs-unstable)' \
         'url:URL:(https:// http://)'
 }
 


### PR DESCRIPTION
Updates the list of nix channels suggested to include recent releases.

Updated list looks like this. Channel count 22 -> 36
```
-- shortcuts --
<nixos>                              <nixos-config>                       <nixpkgs>                          
-- Channel --
channel:                      channel:nixos-16.03           channel:nixos-18.03           channel:nixos-20.03           channel:nixpkgs-18.09-darwin
channel:nixos-13.10           channel:nixos-16.03-small     channel:nixos-18.03-small     channel:nixos-20.03-small     channel:nixpkgs-19.03-darwin
channel:nixos-14.04           channel:nixos-16.09           channel:nixos-18.09           channel:nixos-20.09           channel:nixpkgs-19.09-darwin
channel:nixos-14.04-small     channel:nixos-16.09-small     channel:nixos-18.09-small     channel:nixos-20.09-small     channel:nixpkgs-20.03-darwin
channel:nixos-14.12           channel:nixos-17.03           channel:nixos-19.03           channel:nixos-unstable        channel:nixpkgs-20.09-darwin
channel:nixos-14.12-small     channel:nixos-17.03-small     channel:nixos-19.03-small     channel:nixos-unstable-small  channel:nixpkgs-unstable    
channel:nixos-15.09           channel:nixos-17.09           channel:nixos-19.09           channel:nixpkgs-17.09-darwin                              
channel:nixos-15.09-small     channel:nixos-17.09-small     channel:nixos-19.09-small     channel:nixpkgs-18.03-darwin                              
-- URL --
http://                                                                    https://
```