### PR TITLE
nixos-version: Add missing options

### DIFF
--- a/_nixos-version
+++ b/_nixos-version
@@ -4,4 +4,6 @@
 _nix-common-options
 
 _arguments \
-  '(- *)'{--hash,--revision,--configuration-revision,--json}'[Print only the git hash of the channel]'\
+  '(- *)'{--hash,--revision}'[Show the full SHA1 hash of the Git commit from which this configuration was built.]'\
+  '--configuration-revision[Show the configuration revision if available.]'\
+  '--json[Print a JSON representation of the versions of NixOS and the top-level configuration flake.]'

--- a/_nixos-version
+++ b/_nixos-version
@@ -4,4 +4,4 @@
 _nix-common-options
 
 _arguments \
-  '(- *)'{--hash,--revision}'[Print only the git hash of the channel]'\
+  '(- *)'{--hash,--revision,--configuration-revision,--json}'[Print only the git hash of the channel]'\


### PR DESCRIPTION
`nixos-version` was missing the `--configuration-revision` and `--json` options. I'm not a zsh user; I have not tested this. I thought it made sense to update this here while I was already doing the same on [nix-bash-completions#27](https://github.com/hedning/nix-bash-completions/pull/27)