### PR TITLE
nixos-option: Fix infinite recursion when modulesPath is used in <nixos-config>

### DIFF
--- a/_nixos-option
+++ b/_nixos-option
@@ -10,7 +10,7 @@ _nixos-option-opts() {
         mods="{ nixpkgs.hostPlatform = builtins.currentSystem; }"
     fi
     local options='
-      with import <nixpkgs/lib>;
+      with import <nixpkgs/nixos/lib> { };
       (evalModules {
         modules = import <nixpkgs/nixos/modules/module-list.nix> ++ [ '"$mods"' ];
       }).config


### PR DESCRIPTION
The `evalModules` in <nixpkgs/lib> does not handle `mobulesPath` module argument, which is often used in the auto generated `hardware-configuration.nix`

The infinite recursion can be reproduced using:

```sh
$ nix-instantiate --eval --expr '
with import <nixpkgs/lib>;
(evalModules {
  modules = import <nixpkgs/nixos/modules/module-list.nix> ++ [
    (
      { modulesPath, ... }:
      {
        imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
      }
    )
  ];
}).config'
```